### PR TITLE
chore: align agent_name and agent_label values

### DIFF
--- a/.airules/AGENT_SCRIPT.md
+++ b/.airules/AGENT_SCRIPT.md
@@ -58,7 +58,7 @@ Top-level blocks MUST appear in this order:
 ```agentscript
 # 1. CONFIG (required) - Agent metadata
 config:
-   agent_name: "My_Agent"
+   agent_name: "DescriptiveName"
    ...
 
 # 2. VARIABLES (optional) - State management
@@ -166,10 +166,10 @@ config:
 ```agentscript
 config:
    # Required
-   agent_name: "My_Agent_Name"           # Unique identifier (letters, numbers, underscores)
+   agent_name: "DescriptiveName"           # Unique identifier (letters, numbers, underscores)
 
    # Optional with defaults
-   agent_label: "My Agent"               # Display name (defaults to normalized agent_name)
+   agent_label: "DescriptiveName"               # Display name (defaults to normalized agent_name)
    description: "Agent description"       # What the agent does
    agent_type: "AgentforceServiceAgent"  # or "AgentforceEmployeeAgent"
    default_agent_user: "user@example.com" # Required for AgentforceServiceAgent

--- a/force-app/future_recipes/advancedReasoningPatterns/README.md
+++ b/force-app/future_recipes/advancedReasoningPatterns/README.md
@@ -1,4 +1,4 @@
-# AdvancedReasoningPatterns Agent
+# AdvancedReasoningPatterns
 
 ## Overview
 

--- a/force-app/future_recipes/advancedReasoningPatterns/aiAuthoringBundles/AdvancedReasoningPatterns/AdvancedReasoningPatterns.agent
+++ b/force-app/future_recipes/advancedReasoningPatterns/aiAuthoringBundles/AdvancedReasoningPatterns/AdvancedReasoningPatterns.agent
@@ -1,9 +1,9 @@
-# AdvancedReasoningPatterns Agent
+# AdvancedReasoningPatterns
 # Demonstrates complex dynamic reasoning with multiple data sources
 
 config:
    agent_name: "AdvancedReasoningPatterns"
-   agent_label: "Advanced Reasoning Patterns Agent"
+   agent_label: "AdvancedReasoningPatterns"
    description: "Demonstrates advanced reasoning with dynamic instructions and complex logic"
 
 variables:

--- a/force-app/future_recipes/complexStateManagement/README.md
+++ b/force-app/future_recipes/complexStateManagement/README.md
@@ -1,4 +1,4 @@
-# ComplexStateManagement Agent
+# ComplexStateManagement
 
 ## Overview
 

--- a/force-app/future_recipes/complexStateManagement/aiAuthoringBundles/ComplexStateManagement/ComplexStateManagement.agent
+++ b/force-app/future_recipes/complexStateManagement/aiAuthoringBundles/ComplexStateManagement/ComplexStateManagement.agent
@@ -1,9 +1,9 @@
-# ComplexStateManagement Agent - Advanced State Manipulation
+# ComplexStateManagement - Advanced State Manipulation
 # This agent demonstrates complex object and list operations for sophisticated state management
 
 config:
-   agent_name: "ComplexStateManagement_Agent"
-   agent_label: "Task Manager Agent"
+   agent_name: "ComplexStateManagement"
+   agent_label: "ComplexStateManagement"
    description: "Manages a todo list with complex state operations"
 
 variables:

--- a/force-app/future_recipes/conditionalLogicPatterns/README.md
+++ b/force-app/future_recipes/conditionalLogicPatterns/README.md
@@ -1,4 +1,4 @@
-# ConditionalLogicPatterns Agent
+# ConditionalLogicPatterns
 
 ## Overview
 

--- a/force-app/future_recipes/conditionalLogicPatterns/aiAuthoringBundles/ConditionalLogicPatterns/ConditionalLogicPatterns.agent
+++ b/force-app/future_recipes/conditionalLogicPatterns/aiAuthoringBundles/ConditionalLogicPatterns/ConditionalLogicPatterns.agent
@@ -1,9 +1,9 @@
-# ConditionalLogicPatterns Agent - Mastering If/Else Control Flow
+# ConditionalLogicPatterns - Mastering If/Else Control Flow
 # This agent demonstrates comprehensive conditional logic patterns
 
 config:
-   agent_name: "ConditionalLogicPatterns_Agent"
-   agent_label: "Loan Approval Agent"
+   agent_name: "ConditionalLogicPatterns"
+   agent_label: "ConditionalLogicPatterns"
    description: "Evaluates loan applications using complex conditional logic"
 
 variables:

--- a/force-app/future_recipes/contextHandling/README.md
+++ b/force-app/future_recipes/contextHandling/README.md
@@ -1,4 +1,4 @@
-# ContextHandling Agent
+# ContextHandling
 
 ## Overview
 

--- a/force-app/future_recipes/contextHandling/aiAuthoringBundles/ContextHandling/ContextHandling.agent
+++ b/force-app/future_recipes/contextHandling/aiAuthoringBundles/ContextHandling/ContextHandling.agent
@@ -1,9 +1,9 @@
-# ContextHandling Agent - Working with Session and Platform Context
+# ContextHandling - Working with Session and Platform Context
 # This agent demonstrates using linked variables from external context
 
 config:
-   agent_name: "ContextHandling_Agent"
-   agent_label: "Personalized Assistant"
+   agent_name: "ContextHandling"
+   agent_label: "ContextHandling"
    description: "Uses platform context for personalized experiences"
 
 variables:

--- a/force-app/future_recipes/dynamicActionRouting/README.md
+++ b/force-app/future_recipes/dynamicActionRouting/README.md
@@ -1,4 +1,4 @@
-# DynamicActionRouting Agent
+# DynamicActionRouting
 
 ## Overview
 

--- a/force-app/future_recipes/escalationPatterns/aiAuthoringBundles/EscalationPatterns/EscalationPatterns.agent
+++ b/force-app/future_recipes/escalationPatterns/aiAuthoringBundles/EscalationPatterns/EscalationPatterns.agent
@@ -2,8 +2,8 @@
 # Demonstrates how to escalate to a human agent using the connections block and @utils.escalate
 
 config:
-   agent_name: "EscalationPatterns_Agent"
-   agent_label: "Escalation Support Agent"
+   agent_name: "EscalationPatterns"
+   agent_label: "EscalationPatterns"
    description: "Demonstrates patterns for escalating to human agents"
 
 connections:

--- a/force-app/future_recipes/instructionActionReferences/aiAuthoringBundles/InstructionActionReferences/InstructionActionReferences.agent
+++ b/force-app/future_recipes/instructionActionReferences/aiAuthoringBundles/InstructionActionReferences/InstructionActionReferences.agent
@@ -2,8 +2,8 @@
 # Demonstrates how to reference actions directly within reasoning instructions
 
 config:
-   agent_name: "InstructionActionReferences_Agent"
-   agent_label: "Action Reference Demo"
+   agent_name: "InstructionActionReferences"
+   agent_label: "InstructionActionReferences"
    description: "Demonstrates embedding action references in instructions"
 
 variables:

--- a/force-app/future_recipes/multiTopicOrchestration/README.md
+++ b/force-app/future_recipes/multiTopicOrchestration/README.md
@@ -1,4 +1,4 @@
-# MultiTopicOrchestration Agent
+# MultiTopicOrchestration
 
 ## Overview
 

--- a/force-app/future_recipes/multiTopicOrchestration/aiAuthoringBundles/MultiTopicOrchestration/MultiTopicOrchestration.agent
+++ b/force-app/future_recipes/multiTopicOrchestration/aiAuthoringBundles/MultiTopicOrchestration/MultiTopicOrchestration.agent
@@ -1,9 +1,9 @@
-# MultiTopicOrchestration Agent
+# MultiTopicOrchestration
 # Demonstrates complex multi-topic workflows with orchestration patterns
 
 config:
-   agent_name: "MultiTopicOrchestration_Agent"
-   agent_label: "Multi-Topic Orchestration Agent"
+   agent_name: "MultiTopicOrchestration"
+   agent_label: "MultiTopicOrchestration"
    description: "Demonstrates complex multi-topic orchestration with specialized topics"
 
 

--- a/force-app/future_recipes/promptTemplateActions/aiAuthoringBundles/PromptTemplateActions/PromptTemplateActions.agent
+++ b/force-app/future_recipes/promptTemplateActions/aiAuthoringBundles/PromptTemplateActions/PromptTemplateActions.agent
@@ -2,8 +2,8 @@
 # Demonstrates how to invoke Salesforce Prompt Templates as actions
 
 config:
-   agent_name: "PromptTemplateActions_Agent"
-   agent_label: "Prompt Template Demo Agent"
+   agent_name: "PromptTemplateActions"
+   agent_label: "PromptTemplateActions"
    description: "Invokes prompt templates for generating content"
 
 variables:

--- a/force-app/future_recipes/safetyAndGuardrails/README.md
+++ b/force-app/future_recipes/safetyAndGuardrails/README.md
@@ -1,4 +1,4 @@
-# SafetyAndGuardrails Agent
+# SafetyAndGuardrails
 
 ## Overview
 

--- a/force-app/future_recipes/safetyAndGuardrails/aiAuthoringBundles/SafetyAndGuardrails/SafetyAndGuardrails.agent
+++ b/force-app/future_recipes/safetyAndGuardrails/aiAuthoringBundles/SafetyAndGuardrails/SafetyAndGuardrails.agent
@@ -1,9 +1,9 @@
-# SafetyAndGuardrails Agent - Production Safety Patterns
+# SafetyAndGuardrails - Production Safety Patterns
 # This agent demonstrates comprehensive safety and confirmation patterns
 
 config:
-   agent_name: "SafetyAndGuardrails_Agent"
-   agent_label: "Data Deletion Agent"
+   agent_name: "SafetyAndGuardrails"
+   agent_label: "SafetyAndGuardrails"
    description: "Handles sensitive data deletion with safety guardrails"
 
 variables:

--- a/force-app/main/01_languageEssentials/templateExpressions/README.md
+++ b/force-app/main/01_languageEssentials/templateExpressions/README.md
@@ -1,4 +1,4 @@
-# TemplateExpressions Agent
+# TemplateExpressions
 
 ## Overview
 

--- a/force-app/main/01_languageEssentials/templateExpressions/aiAuthoringBundles/TemplateExpressions/TemplateExpressions.agent
+++ b/force-app/main/01_languageEssentials/templateExpressions/aiAuthoringBundles/TemplateExpressions/TemplateExpressions.agent
@@ -1,9 +1,9 @@
-# TemplateExpressions Agent - Dynamic Content with Template Syntax
+# TemplateExpressions - Dynamic Content with Template Syntax
 # This agent demonstrates how to use template expressions to create dynamic, personalized responses
 
 config:
-   agent_name: "TemplateExpressions_Agent"
-   agent_label: "Personal Shopping Assistant"
+   agent_name: "TemplateExpressions"
+   agent_label: "TemplateExpressions"
    description: "Personalized shopping assistant using template expressions for dynamic content"
 
 variables:

--- a/force-app/main/03_reasoningMechanics/beforeAfterReasoning/README.md
+++ b/force-app/main/03_reasoningMechanics/beforeAfterReasoning/README.md
@@ -1,4 +1,4 @@
-# BeforeAfterReasoning Agent
+# BeforeAfterReasoning
 
 ## Overview
 

--- a/force-app/main/03_reasoningMechanics/beforeAfterReasoning/aiAuthoringBundles/BeforeAfterReasoning/BeforeAfterReasoning.agent
+++ b/force-app/main/03_reasoningMechanics/beforeAfterReasoning/aiAuthoringBundles/BeforeAfterReasoning/BeforeAfterReasoning.agent
@@ -1,9 +1,9 @@
-# BeforeAfterReasoning Agent
+# BeforeAfterReasoning
 # Demonstrates before_reasoning and after_reasoning lifecycle events
 
 config:
-   agent_name: "BeforeAfterReasoning_Agent"
-   agent_label: "Before/After Reasoning Agent"
+   agent_name: "BeforeAfterReasoning"
+   agent_label: "BeforeAfterReasoning"
    description: "Demonstrates reasoning lifecycle events"
 
 # Variables to track lifecycle execution

--- a/force-app/main/04_architecturalPatterns/externalAPIIntegration/README.md
+++ b/force-app/main/04_architecturalPatterns/externalAPIIntegration/README.md
@@ -1,4 +1,4 @@
-# ExternalAPIIntegration Agent
+# ExternalAPIIntegration
 
 ## Overview
 

--- a/force-app/main/04_architecturalPatterns/multiStepWorkflows/README.md
+++ b/force-app/main/04_architecturalPatterns/multiStepWorkflows/README.md
@@ -1,4 +1,4 @@
-# MultiStepWorkflows Agent
+# MultiStepWorkflows
 
 ## Overview
 

--- a/force-app/main/04_architecturalPatterns/simpleQA/README.md
+++ b/force-app/main/04_architecturalPatterns/simpleQA/README.md
@@ -1,4 +1,4 @@
-# SimpleQA Agent
+# SimpleQA
 
 ## Overview
 

--- a/force-app/main/04_architecturalPatterns/simpleQA/aiAuthoringBundles/SimpleQA/SimpleQA.agent
+++ b/force-app/main/04_architecturalPatterns/simpleQA/aiAuthoringBundles/SimpleQA/SimpleQA.agent
@@ -1,9 +1,9 @@
-# SimpleQA Agent - Basic Question & Answer Agent
+# $1
 # This agent demonstrates how to create a focused Q&A agent with clear instructions
 
 config:
-   agent_name: "SimpleQA_Agent"
-   agent_label: "Product FAQ Agent"
+   agent_name: "SimpleQA"
+   agent_label: "SimpleQA"
    description: "Answers common questions about products and services"
 
 # System block defines the agent's overall personality and capabilities


### PR DESCRIPTION
### What does this PR do?

Align `agent_name` and `agent_label` values across all agents and READMEs for better consistency.
