### PR TITLE
feat: add focus prompt for start_agent block

### DIFF
--- a/force-app/future_recipes/complexStateManagement/aiAuthoringBundles/ComplexStateManagement/ComplexStateManagement.agent
+++ b/force-app/future_recipes/complexStateManagement/aiAuthoringBundles/ComplexStateManagement/ComplexStateManagement.agent
@@ -38,6 +38,8 @@ start_agent topic_selector:
    description: "Welcome users and begin task management"
    
    reasoning:
+      instructions:|
+         Select the tool that best matches the user's message and conversation history. If it's unclear, make your best guess.
       actions:
          begin_task_management: @utils.transition to @topic.task_management
             description: "Start managing tasks with complex state operations"

--- a/force-app/future_recipes/conditionalLogicPatterns/aiAuthoringBundles/ConditionalLogicPatterns/ConditionalLogicPatterns.agent
+++ b/force-app/future_recipes/conditionalLogicPatterns/aiAuthoringBundles/ConditionalLogicPatterns/ConditionalLogicPatterns.agent
@@ -42,11 +42,8 @@ start_agent topic_selector:
    description: "Welcome applicants and begin loan evaluation process"
    
    reasoning:
-      instructions: ->
-         | Welcome to the loan application process. I'll help evaluate your loan application
-           using comprehensive conditional logic to assess eligibility fairly and consistently.
-           Let's start by gathering your information.
-      
+      instructions:|
+         Select the tool that best matches the user's message and conversation history. If it's unclear, make your best guess.
       actions:
          start_evaluation: @utils.transition to @topic.loan_evaluation
             description: "Begin the loan evaluation with conditional logic"

--- a/force-app/future_recipes/contextHandling/aiAuthoringBundles/ContextHandling/ContextHandling.agent
+++ b/force-app/future_recipes/contextHandling/aiAuthoringBundles/ContextHandling/ContextHandling.agent
@@ -44,6 +44,8 @@ start_agent topic_selector:
    description: "Welcome users with personalized greeting based on context"
    
    reasoning:
+      instructions:|
+         Select the tool that best matches the user's message and conversation history. If it's unclear, make your best guess.
       actions:
          begin_service: @utils.transition to @topic.personalized_service
             description: "Start providing personalized service"

--- a/force-app/future_recipes/customerServiceAgent/aiAuthoringBundles/CustomerServiceAgent/CustomerServiceAgent.agent
+++ b/force-app/future_recipes/customerServiceAgent/aiAuthoringBundles/CustomerServiceAgent/CustomerServiceAgent.agent
@@ -62,6 +62,8 @@ start_agent topic_selector:
    description: "Welcome customers and begin issue triage and resolution"
    
    reasoning:
+      instructions:|
+         Select the tool that best matches the user's message and conversation history. If it's unclear, make your best guess.
       actions:
          begin_triage: @utils.transition to @topic.triage
             description: "Start the customer service triage process"

--- a/force-app/future_recipes/escalationPatterns/aiAuthoringBundles/EscalationPatterns/EscalationPatterns.agent
+++ b/force-app/future_recipes/escalationPatterns/aiAuthoringBundles/EscalationPatterns/EscalationPatterns.agent
@@ -27,6 +27,8 @@ start_agent topic_selector:
    description: "Routes the conversation"
    
    reasoning:
+      instructions:|
+         Select the tool that best matches the user's message and conversation history. If it's unclear, make your best guess.
       actions:
          support: @utils.transition to @topic.general_support
             description: "General support topic"

--- a/force-app/future_recipes/instructionActionReferences/aiAuthoringBundles/InstructionActionReferences/InstructionActionReferences.agent
+++ b/force-app/future_recipes/instructionActionReferences/aiAuthoringBundles/InstructionActionReferences/InstructionActionReferences.agent
@@ -20,6 +20,8 @@ start_agent topic_selector:
    description: "Start topic"
    
    reasoning:
+      instructions:|
+         Select the tool that best matches the user's message and conversation history. If it's unclear, make your best guess.
       actions:
          start: @utils.transition to @topic.case_management
 

--- a/force-app/future_recipes/promptTemplateActions/aiAuthoringBundles/PromptTemplateActions/PromptTemplateActions.agent
+++ b/force-app/future_recipes/promptTemplateActions/aiAuthoringBundles/PromptTemplateActions/PromptTemplateActions.agent
@@ -21,6 +21,8 @@ start_agent topic_selector:
    description: "Start topic"
    
    reasoning:
+      instructions:|
+         Select the tool that best matches the user's message and conversation history. If it's unclear, make your best guess.
       actions:
          generate_schedule: @utils.transition to @topic.schedule_generation
             description: "Go to schedule generation"

--- a/force-app/future_recipes/safetyAndGuardrails/aiAuthoringBundles/SafetyAndGuardrails/SafetyAndGuardrails.agent
+++ b/force-app/future_recipes/safetyAndGuardrails/aiAuthoringBundles/SafetyAndGuardrails/SafetyAndGuardrails.agent
@@ -36,6 +36,8 @@ start_agent topic_selector:
    description: "Welcome users and begin data management with safety protocols"
    
    reasoning:
+      instructions:|
+         Select the tool that best matches the user's message and conversation history. If it's unclear, make your best guess.
       actions:
          begin_data_management: @utils.transition to @topic.data_management
             description: "Start data management with safety guardrails"

--- a/force-app/future_recipes/topicDelegation/aiAuthoringBundles/TopicDelegation/TopicDelegation.agent
+++ b/force-app/future_recipes/topicDelegation/aiAuthoringBundles/TopicDelegation/TopicDelegation.agent
@@ -17,7 +17,10 @@ system:
 
 start_agent topic_selector:
    description: "Main entry point"
+   
    reasoning:
+      instructions:|
+         Select the tool that best matches the user's message and conversation history. If it's unclear, make your best guess.
       actions:
          start: @utils.transition to @topic.general_support
 

--- a/force-app/main/01_languageEssentials/languageSettings/aiAuthoringBundles/LanguageSettings/LanguageSettings.agent
+++ b/force-app/main/01_languageEssentials/languageSettings/aiAuthoringBundles/LanguageSettings/LanguageSettings.agent
@@ -29,6 +29,8 @@ start_agent topic_selector:
            If they speak German, say "Hallo".
            Otherwise, use English.
 
+           Select the tool that best matches the user's message and conversation history. If it's unclear, make your best guess.
+
       actions:
          pass: @utils.transition to @topic.main_topic
             description: "Continue to main topic"

--- a/force-app/main/01_languageEssentials/templateExpressions/aiAuthoringBundles/TemplateExpressions/TemplateExpressions.agent
+++ b/force-app/main/01_languageEssentials/templateExpressions/aiAuthoringBundles/TemplateExpressions/TemplateExpressions.agent
@@ -35,6 +35,8 @@ start_agent topic_selector:
    description: "Welcome customers and begin personalized shopping assistance"
    
    reasoning:
+      instructions:|
+         Select the tool that best matches the user's message and conversation history. If it's unclear, make your best guess.
       actions:
          start_shopping: @utils.transition to @topic.shopping_assistant
             description: "Begin the personalized shopping session"

--- a/force-app/main/02_actionConfiguration/actionCallbacks/aiAuthoringBundles/ActionCallbacks/ActionCallbacks.agent
+++ b/force-app/main/02_actionConfiguration/actionCallbacks/aiAuthoringBundles/ActionCallbacks/ActionCallbacks.agent
@@ -36,6 +36,8 @@ start_agent topic_selector:
    description: "Welcome users and begin payment processing"
    
    reasoning:
+      instructions:|
+         Select the tool that best matches the user's message and conversation history. If it's unclear, make your best guess.
       actions:
          begin_payment: @utils.transition to @topic.payment_processing
             description: "Start processing payments with post-action callbacks"

--- a/force-app/main/02_actionConfiguration/actionDescriptionOverrides/aiAuthoringBundles/ActionDescriptionOverrides/ActionDescriptionOverrides.agent
+++ b/force-app/main/02_actionConfiguration/actionDescriptionOverrides/aiAuthoringBundles/ActionDescriptionOverrides/ActionDescriptionOverrides.agent
@@ -20,6 +20,8 @@ start_agent topic_selector:
    description: "Welcome users and determine their expertise level"
    
    reasoning:
+      instructions:|
+         Select the tool that best matches the user's message and conversation history. If it's unclear, make your best guess.
       actions:
          beginner_mode: @utils.transition to @topic.beginner_mode
             description: "Use simplified interface for beginners. Choose this for general questions or when no specific search context (like Accounts or Cases) is mentioned."

--- a/force-app/main/03_reasoningMechanics/beforeAfterReasoning/aiAuthoringBundles/BeforeAfterReasoning/BeforeAfterReasoning.agent
+++ b/force-app/main/03_reasoningMechanics/beforeAfterReasoning/aiAuthoringBundles/BeforeAfterReasoning/BeforeAfterReasoning.agent
@@ -24,6 +24,8 @@ start_agent topic_selector:
    description: "Welcome users and demonstrate reasoning lifecycle events. Transition to the conversation topic to get started."
    
    reasoning:
+      instructions:|
+         Select the tool that best matches the user's message and conversation history. If it's unclear, make your best guess.
       actions:
          begin_conversation: @utils.transition to @topic.conversation
 

--- a/force-app/main/04_architecturalPatterns/bidirectionalNavigation/aiAuthoringBundles/BidirectionalNavigation/BidirectionalNavigation.agent
+++ b/force-app/main/04_architecturalPatterns/bidirectionalNavigation/aiAuthoringBundles/BidirectionalNavigation/BidirectionalNavigation.agent
@@ -31,6 +31,8 @@ start_agent topic_selector:
    description: "Welcome customers and route them to the appropriate support specialist"
    
    reasoning:
+      instructions:|
+         Select the tool that best matches the user's message and conversation history. If it's unclear, make your best guess.
       actions:
          general_support: @utils.transition to @topic.general_support
             description: "Start with general customer support"

--- a/force-app/main/04_architecturalPatterns/multiStepWorkflows/aiAuthoringBundles/MultiStepWorkflows/MultiStepWorkflows.agent
+++ b/force-app/main/04_architecturalPatterns/multiStepWorkflows/aiAuthoringBundles/MultiStepWorkflows/MultiStepWorkflows.agent
@@ -33,6 +33,8 @@ start_agent topic_selector:
     description: "Welcome new customers and begin onboarding workflow"
 
     reasoning:
+        instructions:|
+            Select the tool that best matches the user's message and conversation history. If it's unclear, make your best guess.
         actions:
             begin_onboarding: @utils.transition to @topic.onboarding
                 description: "Start the multi-step customer onboarding workflow"


### PR DESCRIPTION
### What does this PR do?

Not all agents have the recommended focus prompt for the `start_agent` block. This PR adds that.
