### PR TITLE
ci: add 30-second delay after scratch org creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,10 @@ jobs:
             - name: 'Create scratch org'
               run: sf org create scratch -f config/project-scratch-def.json -a scratch-org -d -y 1 -w 10
 
+            # Wait for scratch org to be fully ready
+            - name: 'Wait for scratch org initialization'
+              run: sleep 30
+
             # Assign Manage Prompt Template permission set
             - name: 'Assign Manage Prompt Template permission set'
               run: sf org assign permset -n EinsteinGPTPromptTemplateManager


### PR DESCRIPTION
## Summary
- Add a 30-second delay step after scratch org creation in the CI workflow
- Allows time for the scratch org to fully initialize before deploying source and assigning permission sets

## Test plan
- [x] Verify CI workflow runs successfully with the new delay step
- [x] Confirm scratch org operations complete without timing-related failures