### PR TITLE
feat: add explicit is_required to all action inputs across agent files

### DIFF
--- a/force-app/future_recipes/complexStateManagement/README.md
+++ b/force-app/future_recipes/complexStateManagement/README.md
@@ -151,6 +151,7 @@ subagent task_management:
          inputs:
             tasks: list[object]
                description: "List of task objects to persist"
+               is_required: True
          outputs:
             success: boolean
                description: "Indicates whether tasks were saved"
@@ -163,6 +164,7 @@ subagent task_management:
          inputs:
             tasks: list[object]
                description: "List of task objects to calculate stats from"
+               is_required: True
          outputs:
             stats: object
                description: "Statistics object with completed, pending, rate"

--- a/force-app/future_recipes/complexStateManagement/aiAuthoringBundles/ComplexStateManagement/ComplexStateManagement.agent
+++ b/force-app/future_recipes/complexStateManagement/aiAuthoringBundles/ComplexStateManagement/ComplexStateManagement.agent
@@ -55,6 +55,7 @@ subagent task_management:
          inputs:
             tasks: list[object]
                description: "List of task objects to persist to storage, each containing id, title, status, and priority"
+               is_required: True
          outputs:
             success: boolean
                description: "Indicates whether the tasks were saved successfully"
@@ -68,6 +69,7 @@ subagent task_management:
          inputs:
             tasks: list[object]
                description: "List of task objects to calculate statistics from"
+               is_required: True
          outputs:
             stats: object
                description: "Statistics object containing metrics like completed_tasks, pending_tasks, and completion_rate"

--- a/force-app/future_recipes/conditionalLogicPatterns/aiAuthoringBundles/ConditionalLogicPatterns/ConditionalLogicPatterns.agent
+++ b/force-app/future_recipes/conditionalLogicPatterns/aiAuthoringBundles/ConditionalLogicPatterns/ConditionalLogicPatterns.agent
@@ -57,7 +57,9 @@ subagent loan_evaluation:
          description: "Calculates debt-to-income ratio"
          inputs:
             income: number
+               is_required: True
             loan_amount: number
+               is_required: True
          outputs:
             ratio: number
          target: "flow://CalculateDebtRatio"

--- a/force-app/future_recipes/contextHandling/aiAuthoringBundles/ContextHandling/ContextHandling.agent
+++ b/force-app/future_recipes/contextHandling/aiAuthoringBundles/ContextHandling/ContextHandling.agent
@@ -60,6 +60,7 @@ subagent personalized_service:
          inputs:
             user_id: string
                description: "The unique identifier of the user whose profile to load"
+               is_required: True
          outputs:
             name: string
                description: "The user's display name or full name"
@@ -72,10 +73,13 @@ subagent personalized_service:
          inputs:
             session_id: string
                description: "The unique session identifier for tracking this conversation session"
+               is_required: True
             user_id: string
                description: "The unique identifier of the user in this interaction"
+               is_required: True
             channel: string
                description: "The communication channel used (web, mobile, sms, etc.)"
+               is_required: True
          outputs:
             success: boolean
                description: "Indicates whether the interaction was successfully logged to analytics"

--- a/force-app/future_recipes/customerServiceAgent/aiAuthoringBundles/CustomerServiceAgent/CustomerServiceAgent.agent
+++ b/force-app/future_recipes/customerServiceAgent/aiAuthoringBundles/CustomerServiceAgent/CustomerServiceAgent.agent
@@ -79,6 +79,7 @@ subagent triage:
          inputs:
             customer_id: string
                description: "The unique identifier of the customer to fetch information for"
+               is_required: True
          outputs:
             name: string
                description: "Customer's full name"
@@ -93,6 +94,7 @@ subagent triage:
          inputs:
             issue_description: string
                description: "The customer's description of their issue or problem"
+               is_required: True
          outputs:
             issue_type: string
                description: "Classified issue type (e.g., billing, technical, account, product)"
@@ -107,8 +109,10 @@ subagent triage:
          inputs:
             issue_type: string
                description: "The classified type of issue to search solutions for"
+               is_required: True
             keywords: string
                description: "Keywords extracted from the issue description for refined search"
+               is_required: True
          outputs:
             articles: list[object]
                description: "List of knowledge base article objects matching the search criteria"
@@ -121,14 +125,19 @@ subagent triage:
          inputs:
             customer_id: string
                description: "The unique identifier of the customer the case is for"
+               is_required: True
             subject: string
                description: "Brief subject line summarizing the case"
+               is_required: True
             case_description: string
                description: "Detailed description of the customer's issue"
+               is_required: True
             priority: string
                description: "Priority level of the case (low, medium, high, urgent)"
+               is_required: True
             issue_type: string
                description: "The classified type of issue (billing, technical, account, product)"
+               is_required: True
          outputs:
             case_id: string
                description: "Unique identifier assigned to the newly created case"
@@ -141,10 +150,13 @@ subagent triage:
          inputs:
             case_id: string
                description: "The unique identifier of the case to update"
+               is_required: True
             status: string
                description: "New status for the case (new, in_progress, resolved, escalated, closed)"
+               is_required: True
             notes: string
                description: "Notes or comments about the case update"
+               is_required: False
          outputs:
             updated: boolean
                description: "Indicates whether the case was updated successfully"
@@ -155,10 +167,13 @@ subagent triage:
          inputs:
             case_id: string
                description: "The unique identifier of the case to escalate"
+               is_required: True
             reason: string
                description: "Reason for escalation (e.g., complex issue, customer request, policy exception)"
+               is_required: True
             specialist_team: string
                description: "The specialist team to escalate to based on issue type"
+               is_required: True
          outputs:
             escalated: boolean
                description: "Indicates whether the case was escalated successfully"
@@ -171,8 +186,10 @@ subagent triage:
          inputs:
             customer_email: string
                description: "Email address to send the satisfaction survey to"
+               is_required: True
             case_id: string
                description: "The case ID to associate with the survey response"
+               is_required: True
          outputs:
             sent: boolean
                description: "Indicates whether the satisfaction survey was sent successfully"
@@ -222,8 +239,10 @@ subagent resolution:
          inputs:
             issue_type: string
                description: "The classified type of issue to search solutions for"
+               is_required: True
             keywords: string
                description: "Keywords extracted from the issue description for refined search"
+               is_required: True
          outputs:
             articles: list[object]
                description: "List of knowledge base article objects matching the search criteria"
@@ -236,14 +255,19 @@ subagent resolution:
          inputs:
             customer_id: string
                description: "The unique identifier of the customer the case is for"
+               is_required: True
             subject: string
                description: "Brief subject line summarizing the case"
+               is_required: True
             case_description: string
                description: "Detailed description of the customer's issue"
+               is_required: True
             priority: string
                description: "Priority level of the case (low, medium, high, urgent)"
+               is_required: True
             issue_type: string
                description: "The classified type of issue (billing, technical, account, product)"
+               is_required: True
          outputs:
             case_id: string
                description: "Unique identifier assigned to the newly created case"
@@ -256,10 +280,13 @@ subagent resolution:
          inputs:
             case_id: string
                description: "The unique identifier of the case to update"
+               is_required: True
             status: string
                description: "New status for the case (new, in_progress, resolved, escalated, closed)"
+               is_required: True
             notes: string
                description: "Notes or comments about the case update"
+               is_required: False
          outputs:
             updated: boolean
                description: "Indicates whether the case was updated successfully"
@@ -313,10 +340,13 @@ subagent solution_presentation:
          inputs:
             case_id: string
                description: "The unique identifier of the case to update"
+               is_required: True
             status: string
                description: "New status for the case (new, in_progress, resolved, escalated, closed)"
+               is_required: True
             notes: string
                description: "Notes or comments about the case update"
+               is_required: False
          outputs:
             updated: boolean
                description: "Indicates whether the case was updated successfully"
@@ -354,10 +384,13 @@ subagent escalation:
          inputs:
             case_id: string
                description: "The unique identifier of the case to escalate"
+               is_required: True
             reason: string
                description: "Reason for escalation (e.g., complex issue, customer request, policy exception)"
+               is_required: True
             specialist_team: string
                description: "The specialist team to escalate to based on issue type"
+               is_required: True
          outputs:
             escalated: boolean
                description: "Indicates whether the case was escalated successfully"
@@ -370,10 +403,13 @@ subagent escalation:
          inputs:
             case_id: string
                description: "The unique identifier of the case to update"
+               is_required: True
             status: string
                description: "New status for the case (new, in_progress, resolved, escalated, closed)"
+               is_required: True
             notes: string
                description: "Notes or comments about the case update"
+               is_required: False
          outputs:
             updated: boolean
                description: "Indicates whether the case was updated successfully"
@@ -417,8 +453,10 @@ subagent closure:
          inputs:
             customer_email: string
                description: "Email address to send the satisfaction survey to"
+               is_required: True
             case_id: string
                description: "The case ID to associate with the survey response"
+               is_required: True
          outputs:
             sent: boolean
                description: "Indicates whether the satisfaction survey was sent successfully"

--- a/force-app/future_recipes/dynamicActionRouting/aiAuthoringBundles/DynamicActionRouting/DynamicActionRouting.agent
+++ b/force-app/future_recipes/dynamicActionRouting/aiAuthoringBundles/DynamicActionRouting/DynamicActionRouting.agent
@@ -115,6 +115,7 @@ subagent ticket_management:
            inputs:
                ticket_number: string
                    description: "The unique identifier of the ticket/case to view"
+                   is_required: True
            outputs:
                ticket_info: object
                    description: "Complete ticket information including status, priority, description, and history"
@@ -125,8 +126,10 @@ subagent ticket_management:
            inputs:
                ticket_id: string
                    description: "The unique identifier of the ticket to add a comment to"
+                   is_required: True
                comment: string
                    description: "The comment text to add to the ticket"
+                   is_required: True
            outputs:
                success: boolean
                    description: "Indicates whether the comment was added successfully"
@@ -137,8 +140,10 @@ subagent ticket_management:
            inputs:
                ticket_id: string
                    description: "The unique identifier of the ticket to assign"
+                   is_required: True
                agent: string
                    description: "The name or ID of the agent to assign the ticket to"
+                   is_required: True
            outputs:
                success: boolean
                    description: "Indicates whether the ticket was assigned successfully"
@@ -149,8 +154,10 @@ subagent ticket_management:
            inputs:
                ticket_id: string
                    description: "The unique identifier of the ticket to update"
+                   is_required: True
                new_status: string
                    description: "New status to set (assigned, in_progress, resolved, closed)"
+                   is_required: True
            outputs:
                success: boolean
                    description: "Indicates whether the status was updated successfully"
@@ -161,6 +168,7 @@ subagent ticket_management:
            inputs:
                ticket_id: string
                    description: "The unique identifier of the resolved ticket to close"
+                   is_required: True
            outputs:
                success: boolean
                    description: "Indicates whether the ticket was closed successfully"
@@ -171,8 +179,10 @@ subagent ticket_management:
            inputs:
                ticket_id: string
                    description: "The unique identifier of the ticket to escalate"
+                   is_required: True
                reason: string
                    description: "Reason for escalation (e.g., complexity, urgency, customer request)"
+                   is_required: True
            outputs:
                success: boolean
                    description: "Indicates whether the ticket was escalated successfully"
@@ -183,6 +193,7 @@ subagent ticket_management:
            inputs:
                ticket_id: string
                    description: "The unique identifier of the ticket to permanently delete"
+                   is_required: True
            outputs:
                success: boolean
                    description: "Indicates whether the ticket was deleted successfully"
@@ -193,8 +204,10 @@ subagent ticket_management:
            inputs:
                ticket_id: string
                    description: "The unique identifier of the ticket to reassign"
+                   is_required: True
                new_agent: string
                    description: "The name or ID of the agent to reassign the ticket to"
+                   is_required: True
            outputs:
                success: boolean
                    description: "Indicates whether the ticket was reassigned successfully"

--- a/force-app/future_recipes/multiSubagentOrchestration/aiAuthoringBundles/MultiSubagentOrchestration/MultiSubagentOrchestration.agent
+++ b/force-app/future_recipes/multiSubagentOrchestration/aiAuthoringBundles/MultiSubagentOrchestration/MultiSubagentOrchestration.agent
@@ -82,12 +82,16 @@ subagent orchestrator:
          inputs:
             departure: string
                description: "Departure city or airport code"
+               is_required: True
             destination: string
                description: "Destination city or airport code"
+               is_required: True
             travel_date: string
                description: "Flight date in ISO format (YYYY-MM-DD)"
+               is_required: True
             traveler: string
                description: "Name of the traveler for the flight booking"
+               is_required: True
          outputs:
             confirmation_number: string
                description: "Flight booking confirmation number"
@@ -100,12 +104,16 @@ subagent orchestrator:
          inputs:
             city: string
                description: "City where the hotel is located"
+               is_required: True
             checkin: string
                description: "Hotel check-in date in ISO format (YYYY-MM-DD)"
+               is_required: True
             checkout: string
                description: "Hotel check-out date in ISO format (YYYY-MM-DD)"
+               is_required: True
             guest_name: string
                description: "Name of the guest for the hotel reservation"
+               is_required: True
          outputs:
             confirmation_number: string
                description: "Hotel booking confirmation number"
@@ -118,12 +126,16 @@ subagent orchestrator:
          inputs:
             city: string
                description: "City where the rental car will be picked up"
+               is_required: True
             start_date: string
                description: "Car rental start date in ISO format (YYYY-MM-DD)"
+               is_required: True
             end_date: string
                description: "Car rental end date in ISO format (YYYY-MM-DD)"
+               is_required: True
             renter_name: string
                description: "Name of the person renting the car"
+               is_required: True
          outputs:
             confirmation_number: string
                description: "Car rental confirmation number"
@@ -136,12 +148,16 @@ subagent orchestrator:
          inputs:
             email: string
                description: "Email address to send the complete travel itinerary to"
+               is_required: True
             flight_conf: string
                description: "Flight booking confirmation number to include in itinerary"
+               is_required: True
             hotel_conf: string
                description: "Hotel booking confirmation number to include in itinerary"
+               is_required: True
             car_conf: string
                description: "Car rental confirmation number to include in itinerary"
+               is_required: True
          outputs:
             sent: boolean
                description: "Indicates whether the itinerary email was sent successfully"
@@ -191,12 +207,16 @@ subagent flight_booking:
          inputs:
             departure: string
                description: "Departure city or airport code"
+               is_required: True
             destination: string
                description: "Destination city or airport code"
+               is_required: True
             travel_date: string
                description: "Flight date in ISO format (YYYY-MM-DD)"
+               is_required: True
             traveler: string
                description: "Name of the traveler for the flight booking"
+               is_required: True
          outputs:
             confirmation_number: string
                description: "Flight booking confirmation number"
@@ -240,12 +260,16 @@ subagent hotel_booking:
          inputs:
             city: string
                description: "City where the hotel is located"
+               is_required: True
             checkin: string
                description: "Hotel check-in date in ISO format (YYYY-MM-DD)"
+               is_required: True
             checkout: string
                description: "Hotel check-out date in ISO format (YYYY-MM-DD)"
+               is_required: True
             guest_name: string
                description: "Name of the guest for the hotel reservation"
+               is_required: True
          outputs:
             confirmation_number: string
                description: "Hotel booking confirmation number"
@@ -287,12 +311,16 @@ subagent car_booking:
          inputs:
             city: string
                description: "City where the rental car will be picked up"
+               is_required: True
             start_date: string
                description: "Car rental start date in ISO format (YYYY-MM-DD)"
+               is_required: True
             end_date: string
                description: "Car rental end date in ISO format (YYYY-MM-DD)"
+               is_required: True
             renter_name: string
                description: "Name of the person renting the car"
+               is_required: True
          outputs:
             confirmation_number: string
                description: "Car rental confirmation number"

--- a/force-app/future_recipes/subagentDelegation/aiAuthoringBundles/SubagentDelegation/SubagentDelegation.agent
+++ b/force-app/future_recipes/subagentDelegation/aiAuthoringBundles/SubagentDelegation/SubagentDelegation.agent
@@ -51,6 +51,7 @@ subagent specialist:
          description: "Analyzes the account"
          inputs:
             userId: string
+               is_required: True
          outputs:
             status: string
          target: "flow://SpecialistAction"

--- a/force-app/main/01_languageEssentials/templateExpressions/aiAuthoringBundles/TemplateExpressions/TemplateExpressions.agent
+++ b/force-app/main/01_languageEssentials/templateExpressions/aiAuthoringBundles/TemplateExpressions/TemplateExpressions.agent
@@ -51,8 +51,10 @@ subagent shopping_assistant:
          inputs:
             item_name: string
                description: "Name of the product item to add to the cart"
+               is_required: True
             price: number
                description: "Price of the item being added to the cart"
+               is_required: True
          outputs:
             success: boolean
                description: "Indicates whether the item was added to the cart successfully"
@@ -65,8 +67,10 @@ subagent shopping_assistant:
          inputs:
             budget: number
                description: "Customer's budget to tailor recommendations within their price range"
+               is_required: True
             product_name: string
                description: "The type of product to search for by name"
+               is_required: True
          outputs:
             recommendations: list[string]
                description: "List of personalized product recommendations matching budget and preferences"

--- a/force-app/main/02_actionConfiguration/actionCallbacks/README.md
+++ b/force-app/main/02_actionConfiguration/actionCallbacks/README.md
@@ -144,8 +144,10 @@ subagent payment_processing:
          inputs:
             amount: number
                description: "The payment amount to be processed"
+               is_required: True
             method: string
                description: "The mode of the payment"
+               is_required: True
          outputs:
             transaction_id: string
                description: "Unique identifier for the completed transaction"
@@ -158,8 +160,10 @@ subagent payment_processing:
          inputs:
             transaction_id: string
                description: "The transaction ID to include in the receipt"
+               is_required: True
             amount: number
                description: "The payment amount to display on the receipt"
+               is_required: True
          outputs:
             sent: boolean
                description: "Indicates whether the receipt was sent successfully"
@@ -170,6 +174,7 @@ subagent payment_processing:
          inputs:
             amount: number
                description: "The payment amount used to calculate loyalty points"
+               is_required: True
          outputs:
             points: number
                description: "The number of loyalty points awarded to the customer"
@@ -180,6 +185,7 @@ subagent payment_processing:
          inputs:
             transaction_id: string
                description: "The transaction ID to be logged for audit purposes"
+               is_required: True
          outputs:
             success: boolean
                description: "Indicates whether the transaction was logged successfully"

--- a/force-app/main/02_actionConfiguration/actionCallbacks/aiAuthoringBundles/ActionCallbacks/ActionCallbacks.agent
+++ b/force-app/main/02_actionConfiguration/actionCallbacks/aiAuthoringBundles/ActionCallbacks/ActionCallbacks.agent
@@ -52,8 +52,10 @@ subagent payment_processing:
          inputs:
             amount: number
                description: "The payment amount to be processed"
+               is_required: True
             method: string
                description: "The mode of the payment"
+               is_required: True
          outputs:
             transaction_id: string
                description: "Unique identifier for the completed transaction"
@@ -65,8 +67,10 @@ subagent payment_processing:
          inputs:
             transaction_id: string
                description: "The transaction ID to include in the receipt"
+               is_required: True
             amount: number
                description: "The payment amount to display on the receipt"
+               is_required: True
          outputs:
             sent: boolean
                description: "Indicates whether the receipt was sent successfully"
@@ -76,6 +80,7 @@ subagent payment_processing:
          inputs:
             amount: number
                description: "The payment amount used to calculate loyalty points"
+               is_required: True
          outputs:
             points: number
                description: "The number of loyalty points awarded to the customer"
@@ -85,6 +90,7 @@ subagent payment_processing:
          inputs:
             transaction_id: string
                description: "The transaction ID to be logged for audit purposes"
+               is_required: True
          outputs:
             success: boolean
                description: "Indicates whether the transaction was logged successfully"

--- a/force-app/main/02_actionConfiguration/actionDefinitions/README.md
+++ b/force-app/main/02_actionConfiguration/actionDefinitions/README.md
@@ -48,8 +48,10 @@ get_current_weather:
    inputs:
       city_name: string
          description: "The name of the city to get weather for"
+         is_required: True
       units: string
          description: "Temperature units to use (fahrenheit, celsius, or kelvin)"
+         is_required: False
    outputs:
       temperature: number
          description: "Current temperature value in the specified units"
@@ -105,8 +107,10 @@ subagent weather_lookup:
          inputs:
             city_name: string
                description: "The name of the city to get weather for"
+               is_required: True
             units: string
                description: "Temperature units to use (fahrenheit, celsius, or kelvin)"
+               is_required: False
          outputs:
             temperature: number
                description: "Current temperature value in the specified units"
@@ -203,8 +207,10 @@ actions:
       inputs:
          city_name: string
             description: "The name of the city to get weather for"
+            is_required: True
          units: string
             description: "Temperature units to use (fahrenheit, celsius, or kelvin)"
+            is_required: False
       outputs:
          temperature: number
             description: "Current temperature value in the specified units"
@@ -225,8 +231,10 @@ get_forecast:
    inputs:
       city_name: string
          description: "The name of the city to get forecast for"
+         is_required: True
       days: number
          description: "Number of days to include in the forecast (1-10)"
+         is_required: False
    outputs:
       forecast_data: list[object]
          description: "List of daily forecast objects containing temperature, conditions, and precipitation data"
@@ -242,8 +250,10 @@ send_weather_alert:
    inputs:
       message: string
          description: "The alert message content to send to the user"
+         is_required: True
       severity: string
          description: "Severity level of the alert (low, medium, high, or critical)"
+         is_required: True
    outputs:
       alertMessage: string
          description: "The formatted weather alert message that was sent"

--- a/force-app/main/02_actionConfiguration/actionDefinitions/aiAuthoringBundles/ActionDefinitions/ActionDefinitions.agent
+++ b/force-app/main/02_actionConfiguration/actionDefinitions/aiAuthoringBundles/ActionDefinitions/ActionDefinitions.agent
@@ -49,8 +49,10 @@ subagent weather_lookup:
          inputs:
             city_name: string
                description: "The name of the city to get weather for"
+               is_required: True
             units: string
                description: "Temperature units to use (fahrenheit, celsius, or kelvin)"
+               is_required: False
          # Outputs: What the action returns
          outputs:
             temperature: number
@@ -72,8 +74,10 @@ subagent weather_lookup:
          inputs:
             city_name: string
                description: "The name of the city to get forecast for"
+               is_required: True
             days: number
                description: "Number of days to include in the forecast (1-10)"
+               is_required: False
          outputs:
             forecast_data: list[object]
                description: "List of daily forecast objects containing temperature, conditions, and precipitation data"
@@ -87,8 +91,10 @@ subagent weather_lookup:
          inputs:
             message: string
                description: "The alert message content to send to the user"
+               is_required: True
             severity: string
                description: "Severity level of the alert (low, medium, high, or critical)"
+               is_required: True
          outputs:
             alertMessage: string
                description: "The formatted weather alert message that was sent"

--- a/force-app/main/02_actionConfiguration/actionDescriptionOverrides/README.md
+++ b/force-app/main/02_actionConfiguration/actionDescriptionOverrides/README.md
@@ -52,8 +52,10 @@ subagent beginner_mode:
          inputs:
             query: string
                description: "Search query text to find relevant knowledge base articles"
+               is_required: True
             filters: string
                description: "Filter criteria object to refine search results (e.g., type, date range, tags)"
+               is_required: False
          outputs:
             results: list[object]
                description: "List of search result objects containing matching knowledge base articles"
@@ -81,8 +83,10 @@ subagent advanced_mode:
          inputs:
             query: string
                description: "Search query text with support for advanced syntax and operators"
+               is_required: True
             filters: string
                description: "Advanced filter criteria object with type, date range, tags, and custom field filters"
+               is_required: False
          ...
 ```
 
@@ -133,8 +137,10 @@ subagent beginner_mode:
          inputs:
             query: string
                description: "Search query text to find relevant knowledge base articles"
+               is_required: True
             filters: string
                description: "Filter criteria object to refine search results (e.g., type, date range, tags)"
+               is_required: False
          outputs:
             results: list[object]
                description: "List of search result objects containing matching knowledge base articles"

--- a/force-app/main/02_actionConfiguration/actionDescriptionOverrides/aiAuthoringBundles/ActionDescriptionOverrides/ActionDescriptionOverrides.agent
+++ b/force-app/main/02_actionConfiguration/actionDescriptionOverrides/aiAuthoringBundles/ActionDescriptionOverrides/ActionDescriptionOverrides.agent
@@ -43,8 +43,10 @@ subagent beginner_mode:
          inputs:
             query: string
                description: "Search query text to find relevant knowledge base articles"
+               is_required: True
             filters: string
                description: "Filter criteria object to refine search results (e.g., type, date range, tags)"
+               is_required: False
          outputs:
             results: list[object]
                description: "List of search result objects containing matching knowledge base articles"
@@ -74,8 +76,10 @@ subagent advanced_mode:
          inputs:
             query: string
                description: "Search query text with support for advanced syntax and operators"
+               is_required: True
             filters: string
                description: "Advanced filter criteria object with type, date range, tags, and custom field filters"
+               is_required: False
          outputs:
             results: list[object]
                description: "Paginated list of search result objects with relevance scores"
@@ -105,8 +109,10 @@ subagent contextual_search:
          inputs:
             query: string
                description: "Search query text adapted to the current search context"
+               is_required: True
             filters: string
                description: "Context-specific filter criteria object"
+               is_required: False
          outputs:
             results: list[object]
                description: "List of context-relevant search result objects"

--- a/force-app/main/02_actionConfiguration/advancedInputBindings/README.md
+++ b/force-app/main/02_actionConfiguration/advancedInputBindings/README.md
@@ -115,20 +115,27 @@ subagent report_generation:
          inputs:
             report_type: string
                description: "Type of report to generate (e.g., sales, analytics, performance, financial)"
+               is_required: True
             start_date: object
                description: "Report start date in ISO format (YYYY-MM-DD) defining the beginning of the data range"
                complex_data_type_name: "lightning__dateType"
+               is_required: True
             end_date: object
                description: "Report end date in ISO format (YYYY-MM-DD) defining the end of the data range"
                complex_data_type_name: "lightning__dateType"
+               is_required: True
             user_id: string
                description: "The unique identifier of the user generating the report (for access control and audit)"
+               is_required: True
             format: string
                description: "Output format for the report (pdf, csv, excel, or html)"
+               is_required: False
             include_charts: boolean
                description: "Whether to include visual charts and graphs in the report output"
+               is_required: False
             options: string
                description: "Additional report configuration options such as filters, groupings, and custom parameters"
+               is_required: False
          outputs:
             report_url: string
                description: "URL where the generated report can be accessed or downloaded"

--- a/force-app/main/02_actionConfiguration/advancedInputBindings/aiAuthoringBundles/AdvancedInputBindings/AdvancedInputBindings.agent
+++ b/force-app/main/02_actionConfiguration/advancedInputBindings/aiAuthoringBundles/AdvancedInputBindings/AdvancedInputBindings.agent
@@ -51,20 +51,27 @@ subagent report_generation:
          inputs:
             report_type: string
                description: "Type of report to generate (e.g., sales, analytics, performance, financial)"
+               is_required: True
             start_date: object
                description: "Report start date in ISO format (YYYY-MM-DD) defining the beginning of the data range"
                complex_data_type_name: "lightning__dateType"
+               is_required: True
             end_date: object
                description: "Report end date in ISO format (YYYY-MM-DD) defining the end of the data range"
                complex_data_type_name: "lightning__dateType"
+               is_required: True
             user_id: string
                description: "The unique identifier of the user generating the report (for access control and audit)"
+               is_required: True
             format: string
                description: "Output format for the report (pdf, csv, excel, or html)"
+               is_required: False
             include_charts: boolean
                description: "Whether to include visual charts and graphs in the report output"
+               is_required: False
             options: string
                description: "Additional report configuration options such as filters, groupings, and custom parameters"
+               is_required: False
          outputs:
             report_url: string
                description: "URL where the generated report can be accessed or downloaded"

--- a/force-app/main/02_actionConfiguration/instructionActionReferences/aiAuthoringBundles/InstructionActionReferences/InstructionActionReferences.agent
+++ b/force-app/main/02_actionConfiguration/instructionActionReferences/aiAuthoringBundles/InstructionActionReferences/InstructionActionReferences.agent
@@ -35,6 +35,7 @@ subagent case_management:
          inputs:
             subject: string
                description: "Subject of the case"
+               is_required: True
          outputs:
             case_number: string
                description: "The created case number"

--- a/force-app/main/03_reasoningMechanics/afterReasoning/aiAuthoringBundles/AfterReasoning/AfterReasoning.agent
+++ b/force-app/main/03_reasoningMechanics/afterReasoning/aiAuthoringBundles/AfterReasoning/AfterReasoning.agent
@@ -49,8 +49,10 @@ subagent conversation:
          inputs:
             event_type: string
                description: "Type of event being logged (e.g., reasoning_started, reasoning_completed, user_greeted)"
+               is_required: True
             event_data: string
                description: "Additional data or context about the event being logged"
+               is_required: False
          outputs:
             logged: boolean
                description: "Indicates whether the event was successfully logged to the system"

--- a/force-app/main/03_reasoningMechanics/reasoningInstructions/README.md
+++ b/force-app/main/03_reasoningMechanics/reasoningInstructions/README.md
@@ -141,6 +141,7 @@ subagent order_status:
          inputs:
             order_id: string
                description: "The unique order identifier to check the status for"
+               is_required: True
          outputs:
             status: string
                description: "Current order status (pending, shipped, delivered, cancelled)"

--- a/force-app/main/03_reasoningMechanics/reasoningInstructions/aiAuthoringBundles/ReasoningInstructions/ReasoningInstructions.agent
+++ b/force-app/main/03_reasoningMechanics/reasoningInstructions/aiAuthoringBundles/ReasoningInstructions/ReasoningInstructions.agent
@@ -46,6 +46,7 @@ subagent order_status:
          inputs:
             order_id: string
                description: "The unique order identifier to check the status for"
+               is_required: True
          outputs:
             status: string
                description: "Current order status (pending, shipped, delivered, cancelled)"

--- a/force-app/main/04_architecturalPatterns/advancedReasoningPatterns/README.md
+++ b/force-app/main/04_architecturalPatterns/advancedReasoningPatterns/README.md
@@ -225,6 +225,7 @@ subagent intelligent_insights:
          inputs:
             user_id: string
                description: "The unique identifier of the user whose profile to fetch"
+               is_required: False
          outputs:
             profile: object
                description: "User profile object containing name, contact information, and account details"
@@ -236,6 +237,7 @@ subagent intelligent_insights:
          inputs:
             user_id: string
                description: "The unique identifier of the user whose account data to retrieve"
+               is_required: False
          outputs:
             account: object
                description: "Account object with account status, balance, and membership information"
@@ -247,8 +249,10 @@ subagent intelligent_insights:
          inputs:
             user_id: string
                description: "The unique identifier of the user whose order history to fetch"
+               is_required: False
             limit: number
                description: "Maximum number of recent orders to return (e.g., 10 for last 10 orders)"
+               is_required: False
          outputs:
             orders: list[object]
                description: "List of order objects containing order ID, date, amount, and items for each order"
@@ -260,6 +264,7 @@ subagent intelligent_insights:
          inputs:
             user_id: string
                description: "The unique identifier of the user whose support history to retrieve"
+               is_required: False
          outputs:
             tickets: list[object]
                description: "List of support ticket objects with ticket ID, status, issue type, and resolution details"
@@ -271,9 +276,11 @@ subagent intelligent_insights:
          inputs:
             user_id: string
                description: "The unique identifier of the customer to calculate value for"
+               is_required: False
             orders: list[object]
                description: "List of customer's order history objects used for CLV calculation"
                complex_data_type_name: "lightning__recordInfoType"
+               is_required: False
          outputs:
             clv: number
                description: "Calculated customer lifetime value as a monetary amount"
@@ -287,12 +294,15 @@ subagent intelligent_insights:
             account: object
                description: "Customer account object with status and activity information"
                complex_data_type_name: "lightning__recordInfoType"
+               is_required: False
             orders: list[object]
                description: "List of customer orders used to analyze purchase patterns and frequency"
                complex_data_type_name: "lightning__recordInfoType"
+               is_required: False
             support_tickets: list[object]
                description: "List of support tickets used to identify potential dissatisfaction indicators"
                complex_data_type_name: "lightning__recordInfoType"
+               is_required: False
          outputs:
             risk_score: number
                description: "Churn risk score as a decimal between 0.0 (low risk) and 1.0 (high risk)"
@@ -307,10 +317,13 @@ subagent intelligent_insights:
             profile: object
                description: "Customer profile object with preferences and demographic information"
                complex_data_type_name: "lightning__recordInfoType"
+               is_required: False
             clv: number
                description: "Customer lifetime value used to tailor recommendations appropriately"
+               is_required: False
             churn_risk: number
                description: "Churn risk score (0.0-1.0) used to prioritize retention-focused recommendations"
+               is_required: False
          outputs:
             recommendations: list[object]
                description: "List of personalized action recommendations for engaging and retaining the customer"

--- a/force-app/main/04_architecturalPatterns/advancedReasoningPatterns/aiAuthoringBundles/AdvancedReasoningPatterns/AdvancedReasoningPatterns.agent
+++ b/force-app/main/04_architecturalPatterns/advancedReasoningPatterns/aiAuthoringBundles/AdvancedReasoningPatterns/AdvancedReasoningPatterns.agent
@@ -141,6 +141,7 @@ subagent intelligent_insights:
          inputs:
             user_id: string
                description: "The unique identifier of the user whose profile to fetch"
+               is_required: False
          outputs:
             profile: object
                description: "User profile object containing name, contact information, and account details"
@@ -152,6 +153,7 @@ subagent intelligent_insights:
          inputs:
             user_id: string
                description: "The unique identifier of the user whose account data to retrieve"
+               is_required: False
          outputs:
             account: object
                description: "Account object with account status, balance, and membership information"
@@ -163,8 +165,10 @@ subagent intelligent_insights:
          inputs:
             user_id: string
                description: "The unique identifier of the user whose order history to fetch"
+               is_required: False
             limit: number
                description: "Maximum number of recent orders to return (e.g., 10 for last 10 orders)"
+               is_required: False
          outputs:
             orders: list[object]
                description: "List of order objects containing order ID, date, amount, and items for each order"
@@ -176,6 +180,7 @@ subagent intelligent_insights:
          inputs:
             user_id: string
                description: "The unique identifier of the user whose support history to retrieve"
+               is_required: False
          outputs:
             tickets: list[object]
                description: "List of support ticket objects with ticket ID, status, issue type, and resolution details"
@@ -187,9 +192,11 @@ subagent intelligent_insights:
          inputs:
             user_id: string
                description: "The unique identifier of the customer to calculate value for"
+               is_required: False
             orders: list[object]
                description: "List of customer's order history objects used for CLV calculation"
                complex_data_type_name: "lightning__recordInfoType"
+               is_required: False
          outputs:
             clv: number
                description: "Calculated customer lifetime value as a monetary amount"
@@ -203,12 +210,15 @@ subagent intelligent_insights:
             account: object
                description: "Customer account object with status and activity information"
                complex_data_type_name: "lightning__recordInfoType"
+               is_required: False
             orders: list[object]
                description: "List of customer orders used to analyze purchase patterns and frequency"
                complex_data_type_name: "lightning__recordInfoType"
+               is_required: False
             support_tickets: list[object]
                description: "List of support tickets used to identify potential dissatisfaction indicators"
                complex_data_type_name: "lightning__recordInfoType"
+               is_required: False
          outputs:
             risk_score: number
                description: "Churn risk score as a decimal between 0.0 (low risk) and 1.0 (high risk)"
@@ -223,10 +233,13 @@ subagent intelligent_insights:
             profile: object
                description: "Customer profile object with preferences and demographic information"
                complex_data_type_name: "lightning__recordInfoType"
+               is_required: False
             clv: number
                description: "Customer lifetime value used to tailor recommendations appropriately"
+               is_required: False
             churn_risk: number
                description: "Churn risk score (0.0-1.0) used to prioritize retention-focused recommendations"
+               is_required: False
          outputs:
             recommendations: list[object]
                description: "List of personalized action recommendations for engaging and retaining the customer"

--- a/force-app/main/04_architecturalPatterns/bidirectionalNavigation/README.md
+++ b/force-app/main/04_architecturalPatterns/bidirectionalNavigation/README.md
@@ -74,6 +74,7 @@ subagent technical_specialist:
          inputs:
             issue_description: string
                description: "Detailed description of the technical issue to analyze"
+               is_required: True
          outputs:
             assessment: string
                description: "Technical assessment and diagnosis of the issue"
@@ -108,8 +109,10 @@ subagent billing_specialist:
          inputs:
             issue_description: string
                description: "Description of the billing issue or inquiry"
+               is_required: True
             customer_id: string
                description: "The unique identifier of the customer"
+               is_required: True
          outputs:
             analysis: string
                description: "Analysis of the billing issue"

--- a/force-app/main/04_architecturalPatterns/bidirectionalNavigation/aiAuthoringBundles/BidirectionalNavigation/BidirectionalNavigation.agent
+++ b/force-app/main/04_architecturalPatterns/bidirectionalNavigation/aiAuthoringBundles/BidirectionalNavigation/BidirectionalNavigation.agent
@@ -48,6 +48,7 @@ subagent general_support:
          inputs:
             issue_description: string
                description: "Detailed description of the technical issue to analyze"
+               is_required: True
          outputs:
             assessment: string
                description: "Technical assessment and diagnosis of the issue"
@@ -60,8 +61,10 @@ subagent general_support:
          inputs:
             issue_description: string
                description: "Description of the billing issue or inquiry"
+               is_required: True
             customer_id: string
                description: "The unique identifier of the customer with the billing issue"
+               is_required: True
          outputs:
             analysis: string
                description: "Analysis of the billing issue including account review and findings"
@@ -74,10 +77,13 @@ subagent general_support:
          inputs:
             issue_type: string
                description: "Type of issue being escalated (technical, billing, general)"
+               is_required: True
             issue_description: string
                description: "Detailed description of the issue requiring escalation"
+               is_required: True
             customer_id: string
                description: "The unique identifier of the customer for the escalation ticket"
+               is_required: True
          outputs:
             ticket_id: string
                description: "Unique identifier of the created escalation ticket"
@@ -109,6 +115,7 @@ subagent technical_specialist:
          inputs:
             issue_description: string
                description: "Detailed description of the technical issue to analyze"
+               is_required: True
          outputs:
             assessment: string
                description: "Technical assessment and diagnosis of the issue"
@@ -140,8 +147,10 @@ subagent billing_specialist:
          inputs:
             issue_description: string
                description: "Description of the billing issue or inquiry"
+               is_required: True
             customer_id: string
                description: "The unique identifier of the customer with the billing issue"
+               is_required: True
          outputs:
             analysis: string
                description: "Analysis of the billing issue including account review and findings"

--- a/force-app/main/04_architecturalPatterns/errorHandling/aiAuthoringBundles/ErrorHandling/ErrorHandling.agent
+++ b/force-app/main/04_architecturalPatterns/errorHandling/aiAuthoringBundles/ErrorHandling/ErrorHandling.agent
@@ -56,6 +56,7 @@ subagent account_transfer:
          inputs:
             account_number: string
                description: "The account number to check the balance for"
+               is_required: True
          outputs:
             balance: number
                description: "Current account balance as a monetary amount"
@@ -68,10 +69,13 @@ subagent account_transfer:
          inputs:
             from_account: string
                description: "Source account number to transfer funds from"
+               is_required: True
             to_account: string
                description: "Destination account number to transfer funds to"
+               is_required: True
             amount: number
                description: "Amount of money to transfer (must be positive and within limits)"
+               is_required: True
          outputs:
             success: boolean
                description: "Indicates whether the transfer was completed successfully"

--- a/force-app/main/04_architecturalPatterns/externalAPIIntegration/README.md
+++ b/force-app/main/04_architecturalPatterns/externalAPIIntegration/README.md
@@ -46,6 +46,7 @@ actions:
       description: "Fetch weather data from external API via Apex"
       inputs:
          cityName: string
+            is_required: True
       outputs:
          temperature: object
             complex_data_type_name: "lightning__integerType"
@@ -65,8 +66,11 @@ actions:
       description: "Process payment via external payment gateway using Apex"
       inputs:
          amount: number
+            is_required: True
          paymentToken: string
+            is_required: True
          currencyName: string
+            is_required: False
       outputs:
          transactionId: string
          status: string
@@ -83,7 +87,9 @@ actions:
       description: "Track shipment via external shipping API"
       inputs:
          tracking_number: string
+            is_required: True
          carrier: string
+            is_required: False
       outputs:
          status: string
          estimated_delivery: string
@@ -171,6 +177,7 @@ actions:
       description: "Fetch weather data from external API via Apex"
       inputs:
          cityName: string
+            is_required: True
       outputs:
          temperature: object
             complex_data_type_name: "lightning__integerType"
@@ -185,8 +192,11 @@ actions:
       description: "Process payment via external payment gateway using Apex"
       inputs:
          amount: number
+            is_required: True
          paymentToken: string
+            is_required: True
          currencyName: string
+            is_required: False
       outputs:
          transactionId: string
          status: string
@@ -198,7 +208,9 @@ actions:
       description: "Track shipment via external shipping API"
       inputs:
          tracking_number: string
+            is_required: True
          carrier: string
+            is_required: False
       outputs:
          status: string
          estimated_delivery: string

--- a/force-app/main/04_architecturalPatterns/externalAPIIntegration/aiAuthoringBundles/ExternalAPIIntegration/ExternalAPIIntegration.agent
+++ b/force-app/main/04_architecturalPatterns/externalAPIIntegration/aiAuthoringBundles/ExternalAPIIntegration/ExternalAPIIntegration.agent
@@ -96,6 +96,7 @@ subagent api_integration:
          description: "Fetch weather data from external API via Flow"
          inputs:
             cityName: string
+               is_required: True
          outputs:
             temperature: object
                complex_data_type_name: "lightning__integerType"
@@ -111,8 +112,11 @@ subagent api_integration:
          description: "Process payment via external payment gateway using Apex"
          inputs:
             amount: number
+               is_required: True
             paymentToken: string
+               is_required: True
             currencyName: string
+               is_required: False
          outputs:
             transactionId: string
             status: string
@@ -125,7 +129,9 @@ subagent api_integration:
          description: "Track shipment via external shipping API"
          inputs:
             tracking_number: string
+               is_required: True
             carrier: string
+               is_required: False
          outputs:
             status: string
             estimated_delivery: string

--- a/force-app/main/04_architecturalPatterns/multiStepWorkflows/README.md
+++ b/force-app/main/04_architecturalPatterns/multiStepWorkflows/README.md
@@ -133,8 +133,10 @@ actions:
         inputs:
             email: string
                 description: "Customer's email address for account registration and verification"
+                is_required: True
             name: string
                 description: "Customer's full name for the account"
+                is_required: True
         outputs:
             customer_id: string
                 description: "Unique identifier assigned to the newly created customer account"
@@ -149,8 +151,10 @@ actions:
         inputs:
             customer_id: string
                 description: "The unique identifier of the customer to send verification email to"
+                is_required: True
             email: string
                 description: "The email address where the verification link will be sent"
+                is_required: True
         outputs:
             token: string
                 description: "Verification token generated for email confirmation"
@@ -163,8 +167,10 @@ actions:
         inputs:
             customer_id: string
                 description: "The unique identifier of the customer whose profile to set up"
+                is_required: True
             preferences: string
                 description: "Customer preferences as JSON object"
+                is_required: True
         outputs:
             profile_id: string
                 description: "Unique identifier for the newly created customer profile"
@@ -177,8 +183,10 @@ actions:
         inputs:
             customer_id: string
                 description: "The unique identifier of the customer whose settings to configure"
+                is_required: True
             settings: string
                 description: "Account privacy settings as JSON object"
+                is_required: True
         outputs:
             success: boolean
                 description: "Indicates whether the privacy settings were configured successfully"
@@ -189,6 +197,7 @@ actions:
         inputs:
             customer_id: string
                 description: "The unique identifier of the customer to finalize onboarding for"
+                is_required: True
         outputs:
             success: boolean
                 description: "Indicates whether onboarding was finalized successfully"

--- a/force-app/main/04_architecturalPatterns/multiStepWorkflows/aiAuthoringBundles/MultiStepWorkflows/MultiStepWorkflows.agent
+++ b/force-app/main/04_architecturalPatterns/multiStepWorkflows/aiAuthoringBundles/MultiStepWorkflows/MultiStepWorkflows.agent
@@ -98,8 +98,10 @@ subagent onboarding:
             inputs:
                 email: string
                     description: "Customer's email address for account registration and verification"
+                    is_required: True
                 name: string
                     description: "Customer's full name for the account"
+                    is_required: True
             outputs:
                 customer_id: string
                     description: "Unique identifier assigned to the newly created customer account"
@@ -114,8 +116,10 @@ subagent onboarding:
             inputs:
                 customer_id: string
                     description: "The unique identifier of the customer to send verification email to"
+                    is_required: True
                 email: string
                     description: "The email address where the verification link will be sent"
+                    is_required: True
             outputs:
                 token: string
                     description: "Verification token generated for email confirmation"
@@ -128,8 +132,10 @@ subagent onboarding:
             inputs:
                 customer_id: string
                     description: "The unique identifier of the customer whose profile to set up"
+                    is_required: True
                 preferences: string
                     description: "Customer preferences as JSON object"
+                    is_required: True
             outputs:
                 profile_id: string
                     description: "Unique identifier for the newly created customer profile"
@@ -142,8 +148,10 @@ subagent onboarding:
             inputs:
                 customer_id: string
                     description: "The unique identifier of the customer whose settings to configure"
+                    is_required: True
                 settings: string
                     description: "Account privacy settings as JSON object"
+                    is_required: True
             outputs:
                 success: boolean
                     description: "Indicates whether the privacy settings were configured successfully"
@@ -154,6 +162,7 @@ subagent onboarding:
             inputs:
                 customer_id: string
                     description: "The unique identifier of the customer to finalize onboarding for"
+                    is_required: True
             outputs:
                 success: boolean
                     description: "Indicates whether onboarding was finalized successfully"

--- a/force-app/main/04_architecturalPatterns/multiSubagentNavigation/README.md
+++ b/force-app/main/04_architecturalPatterns/multiSubagentNavigation/README.md
@@ -125,10 +125,13 @@ subagent hotel_browse:
          inputs:
             location: string
                description: "City or location to search for hotels in"
+               is_required: True
             check_in: string
                description: "Check-in date in ISO format (YYYY-MM-DD)"
+               is_required: True
             check_out: string
                description: "Check-out date in ISO format (YYYY-MM-DD)"
+               is_required: True
          outputs:
             hotels: list[object]
                description: "List of available hotel objects with name, price, rating, and amenities information"
@@ -167,10 +170,13 @@ subagent hotel_booking:
          inputs:
             hotel_name: string
                description: "Name of the hotel to book"
+               is_required: True
             check_in: string
                description: "Check-in date in ISO format (YYYY-MM-DD)"
+               is_required: True
             check_out: string
                description: "Check-out date in ISO format (YYYY-MM-DD)"
+               is_required: True
          outputs:
             booking_id: string
                description: "Unique booking confirmation identifier"

--- a/force-app/main/04_architecturalPatterns/multiSubagentNavigation/aiAuthoringBundles/MultiSubagentNavigation/MultiSubagentNavigation.agent
+++ b/force-app/main/04_architecturalPatterns/multiSubagentNavigation/aiAuthoringBundles/MultiSubagentNavigation/MultiSubagentNavigation.agent
@@ -58,10 +58,13 @@ subagent hotel_browse:
          inputs:
             location: string
                description: "City or location to search for hotels in"
+               is_required: True
             check_in: string
                description: "Check-in date in ISO format (YYYY-MM-DD)"
+               is_required: True
             check_out: string
                description: "Check-out date in ISO format (YYYY-MM-DD)"
+               is_required: True
          outputs:
             hotels: list[object]
                description: "List of available hotel objects with name, price, rating, and amenities information"
@@ -97,10 +100,13 @@ subagent hotel_booking:
          inputs:
             hotel_name: string
                description: "Name of the hotel to book"
+               is_required: True
             check_in: string
                description: "Check-in date in ISO format (YYYY-MM-DD)"
+               is_required: True
             check_out: string
                description: "Check-out date in ISO format (YYYY-MM-DD)"
+               is_required: True
          outputs:
             booking_id: string
                description: "Unique booking confirmation identifier"

--- a/force-app/main/04_architecturalPatterns/safetyAndGuardrails/README.md
+++ b/force-app/main/04_architecturalPatterns/safetyAndGuardrails/README.md
@@ -149,6 +149,7 @@ actions:
       inputs:
          record_id: string
             description: "The unique identifier of the record to check for dependencies"
+            is_required: True
       outputs:
          count: number
             description: "The number of dependent records that would be affected by deletion"
@@ -159,6 +160,7 @@ actions:
       inputs:
          record_id: string
             description: "The unique identifier of the record to permanently delete"
+            is_required: True
       outputs:
          success: boolean
             description: "Indicates whether the record was deleted successfully"

--- a/force-app/main/04_architecturalPatterns/safetyAndGuardrails/aiAuthoringBundles/SafetyAndGuardrails/SafetyAndGuardrails.agent
+++ b/force-app/main/04_architecturalPatterns/safetyAndGuardrails/aiAuthoringBundles/SafetyAndGuardrails/SafetyAndGuardrails.agent
@@ -86,6 +86,7 @@ subagent data_management:
          inputs:
             record_id: string
                description: "The unique identifier of the record to check for dependencies"
+               is_required: True
          outputs:
             count: number
                description: "The number of dependent records that would be affected by deletion"
@@ -96,6 +97,7 @@ subagent data_management:
          inputs:
             record_id: string
                description: "The unique identifier of the record to permanently delete"
+               is_required: True
          outputs:
             success: boolean
                description: "Indicates whether the record was deleted successfully"

--- a/force-app/main/04_architecturalPatterns/simpleQA/README.md
+++ b/force-app/main/04_architecturalPatterns/simpleQA/README.md
@@ -106,6 +106,7 @@ actions:
       inputs:
          product_name: string
             description: "Name of the product to look up information for"
+            is_required: True
       outputs:
          product_details: string
             description: "Detailed product information including features, specifications, and description"

--- a/force-app/main/04_architecturalPatterns/simpleQA/aiAuthoringBundles/SimpleQA/SimpleQA.agent
+++ b/force-app/main/04_architecturalPatterns/simpleQA/aiAuthoringBundles/SimpleQA/SimpleQA.agent
@@ -40,6 +40,7 @@ subagent product_qa:
          inputs:
             product_name: string
                description: "Name of the product to look up information for"
+               is_required: True
          outputs:
             product_details: string
                description: "Detailed product information including features, specifications, and description"


### PR DESCRIPTION
## Summary

- Adds explicit `is_required: True` or `is_required: False` to every action input across all `.agent` files under `force-app/main/` and `force-app/future_recipes/`
- The new Agentforce Builder validation requires `is_required` to be declared explicitly on every action input, even when the value is `False` — omitting it now produces a compilation error
- `is_required` is applied to inputs only (not outputs), as confirmed with the engineering team — the field is not valid on outputs

Closes #75