### PR TITLE
fix: add graph runtime for custom lightning types recipe

### DIFF
--- a/force-app/main/02_actionConfiguration/customLightningTypes/README.md
+++ b/force-app/main/02_actionConfiguration/customLightningTypes/README.md
@@ -1,6 +1,6 @@
 # CustomLightningTypes
 
-> **Known Platform Bug**: The CLT output renderer card does **not** render in the Agentforce **Builder preview panel**. This is a bug. You have to commit and activate the agent to test this recipe. Use the Builder to activate the recipe.
+> **Known Platform Bug**: The CLT output renderer card does **not** render in the Agentforce **Builder preview panel if the agent is in Draft mode**. This is a bug. You have to commit and activate the agent to get it to work. Use the Agentforce Builder to commit the recipe and then activate to test this recipe.
 
 > **Setup Requirement**: To test this recipe in the deployed experience like Salesforce app, the user's Permission Set must include **Agent access to the CustomLightningTypes agent**. Without this, the agent will not be available in the Agentforce chat experience.
 

--- a/force-app/main/02_actionConfiguration/customLightningTypes/README.md
+++ b/force-app/main/02_actionConfiguration/customLightningTypes/README.md
@@ -1,6 +1,6 @@
 # CustomLightningTypes
 
-> **Known Platform Bug**: The CLT output renderer card does **not** render sometimes in the Agentforce **Builder preview panel**. The data pipeline is fully functional — the `result` array is correctly populated with `copilotActionOutput/Submit_Case` and the case data — but the Builder preview UI does not instantiate the renderer LWC. The CLT output card **does render correctly** in the actual deployed Agentforce experience. The CLT input editor works in both the Builder preview and the deployed experience. This appears to be a Salesforce platform limitation specific to the Builder preview for output renderers.
+> **Known Platform Bug**: The CLT output renderer card does **not** render in the Agentforce **Builder preview panel**. This is a bug. You have to commit and activate the agent to test this recipe. Use the Builder to activate the recipe.
 
 > **Setup Requirement**: To test this recipe in the deployed experience like Salesforce app, the user's Permission Set must include **Agent access to the CustomLightningTypes agent**. Without this, the agent will not be available in the Agentforce chat experience.
 

--- a/force-app/main/02_actionConfiguration/customLightningTypes/aiAuthoringBundles/CustomLightningTypes/CustomLightningTypes.agent
+++ b/force-app/main/02_actionConfiguration/customLightningTypes/aiAuthoringBundles/CustomLightningTypes/CustomLightningTypes.agent
@@ -6,6 +6,7 @@ config:
    agent_label: "CustomLightningTypes"
    agent_type: "AgentforceEmployeeAgent"
    description: "Submits support cases using Custom Lightning Types for rich input and output UI"
+   additional_parameter__enable_graph_runtime: True
 
 variables:
    case_submitted: mutable boolean = False


### PR DESCRIPTION
### What does this PR do?

This adds a specific parameter to enable graph runtime. The custom lightning types recipe rendering works well. There is still a product bug that being worked out to ensure the preview works even in the draft mode. It does work now fine when the agent is activated.

Eventually the graph runtime will be enabled for the agents by default and we do not have to explicitly do this.

### What issues does this PR fix or reference?

#<Insert GitHub Issue>

## The PR fulfills these requirements:

[ ] Tests for the proposed changes have been added/updated.
[ ] Code linting and formatting was performed.

### Functionality Before

<insert gif and/or summary>

### Functionality After

<insert gif and/or summary>
