### PR TITLE
fix: remove daisy chain runtime parameter as the engine is updated now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ logs
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+trace.md
 
 # Dependency directories
 node_modules/

--- a/force-app/main/02_actionConfiguration/customLightningTypes/aiAuthoringBundles/CustomLightningTypes/CustomLightningTypes.agent
+++ b/force-app/main/02_actionConfiguration/customLightningTypes/aiAuthoringBundles/CustomLightningTypes/CustomLightningTypes.agent
@@ -6,7 +6,6 @@ config:
    agent_label: "CustomLightningTypes"
    agent_type: "AgentforceEmployeeAgent"
    description: "Submits support cases using Custom Lightning Types for rich input and output UI"
-   additional_parameter__enable_graph_runtime: True
 
 variables:
    case_submitted: mutable boolean = False


### PR DESCRIPTION
### What does this PR do?

Removes the parameter `additional_parameter__enable_graph_runtime` as all the orgs have this updated now.

### What issues does this PR fix or reference?

#N/A

## The PR fulfills these requirements:

[ ] Tests for the proposed changes have been added/updated.
[ ] Code linting and formatting was performed.

### Functionality Before

<insert gif and/or summary>

### Functionality After

<insert gif and/or summary>
