### PR TITLE
fix: Fixes dead links in the README for the list-variables recipe

### DIFF
--- a/force-app/main/01_languageEssentials/listVariables/README.md
+++ b/force-app/main/01_languageEssentials/listVariables/README.md
@@ -102,9 +102,9 @@ Agent: Thanks! Here's your standup summary:
 
 ## What's Next
 
-- **[VariableManagement](../variableManagement/)**: Fundamentals of scalar variables (string, number, boolean)
-- **[TemplateExpressions](../templateExpressions/)**: More on `{!...}` syntax in instructions
-- **[ActionChaining](../../02_actionConfiguration/actionChaining/)**: Populate lists dynamically with `set @variables.list = @outputs.result`
+- **VariableManagement**: Fundamentals of scalar variables (string, number, boolean)
+- **TemplateExpressions**: More on `{!...}` syntax in instructions
+- **ActionChaining**: Populate lists dynamically with `set @variables.list = @outputs.result`
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- Fixes dead links in the README's "What's Next" section to match the plain bold-text convention used by all other recipes